### PR TITLE
feat(serialization): add serialization based on specific header value

### DIFF
--- a/doc/EasyNetQ.HostedService.xml
+++ b/doc/EasyNetQ.HostedService.xml
@@ -277,6 +277,21 @@
              <c>type</c> property.
              </summary>
         </member>
+        <member name="M:EasyNetQ.HostedService.Internals.UnhandledHeaderTypeException.#ctor">
+            <inheritdoc />
+        </member>
+        <member name="M:EasyNetQ.HostedService.Internals.UnhandledHeaderTypeException.#ctor(System.String)">
+            <inheritdoc />
+        </member>
+        <member name="M:EasyNetQ.HostedService.Internals.UnhandledHeaderTypeException.#ctor(System.String,System.Object[])">
+            <inheritdoc />
+        </member>
+        <member name="M:EasyNetQ.HostedService.Internals.UnhandledHeaderTypeException.#ctor(System.String,System.Exception)">
+            <inheritdoc />
+        </member>
+        <member name="M:EasyNetQ.HostedService.Internals.UnhandledHeaderTypeException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+            <inheritdoc />
+        </member>
         <member name="T:EasyNetQ.HostedService.Internals.UnhandledMessageTypeException">
             <summary>
             Thrown when a consumer's <see cref="T:EasyNetQ.IMessage`1"/> default handler for <see cref="T:System.Object"/> is run, since
@@ -819,7 +834,7 @@
              producer as a singleton hosted service.
              </returns>
         </member>
-        <member name="M:EasyNetQ.HostedService.RabbitMqService`1.CreateLazyBus(EasyNetQ.HostedService.Abstractions.IRabbitMqConfig,System.Boolean,System.Boolean,System.IServiceProvider)">
+        <member name="M:EasyNetQ.HostedService.RabbitMqService`1.CreateLazyBus(EasyNetQ.HostedService.Abstractions.IRabbitMqConfig,EasyNetQ.HostedService.Internals.MessageSerializationStrategy,System.Boolean,EasyNetQ.HostedService.Internals.HeaderTypeSerializationConfiguration,System.IServiceProvider)">
              <summary>
              This static method is used by <see cref="T:EasyNetQ.HostedService.DependencyInjection.RabbitMqServiceBuilder`1"/> to construct a singleton hosted
              service for a consumer of a producer.
@@ -834,7 +849,7 @@
              <see cref="T:EasyNetQ.HostedService.DependencyInjection.RabbitMqServiceBuilder`1"/>.
              </summary>
              <param name="rmqConfig"/>
-             <param name="useStronglyTypedMessages"/>
+             <param name="messageSerializationStrategy"/>
              <param name="useCorrelationIds"/>
              <param name="serviceProvider"/>
              <returns/>

--- a/src/EasyNetQ.HostedService/DependencyInjection/RabbitMqServiceBuilder.cs
+++ b/src/EasyNetQ.HostedService/DependencyInjection/RabbitMqServiceBuilder.cs
@@ -26,8 +26,9 @@ namespace EasyNetQ.HostedService.DependencyInjection
     /// </example>
     public sealed class RabbitMqServiceBuilder<T> where T : RabbitMqService<T>
     {
-        private bool _configUseStronglyTypedMessages;
+        private MessageSerializationStrategy _configUseStronglyTypedMessages = MessageSerializationStrategy.UnTyped;
         private bool _configUseCorrelationIds;
+        private HeaderTypeSerializationConfiguration _headerTypeSerializationConfiguration;
         private IRabbitMqConfig _configRabbitMqConfig;
         private readonly List<OnConnectedCallback> _configOnConnected = new List<OnConnectedCallback>();
 
@@ -45,10 +46,17 @@ namespace EasyNetQ.HostedService.DependencyInjection
         {
             get
             {
-                _configUseStronglyTypedMessages = true;
+                _configUseStronglyTypedMessages = MessageSerializationStrategy.Typed;
 
                 return this;
             }
+        }
+        
+        public RabbitMqServiceBuilder<T> WithHeaderTypedMessages(HeaderTypeSerializationConfiguration configuration)
+        {
+            _configUseStronglyTypedMessages = MessageSerializationStrategy.Header;
+            _headerTypeSerializationConfiguration = configuration;
+            return this;
         }
 
         /// <summary>
@@ -173,7 +181,7 @@ namespace EasyNetQ.HostedService.DependencyInjection
                         .BuildServiceProvider();
 
                 var bus = RabbitMqService<T>.CreateLazyBus(
-                    _configRabbitMqConfig, _configUseStronglyTypedMessages, _configUseCorrelationIds, serviceProvider);
+                    _configRabbitMqConfig, _configUseStronglyTypedMessages, _configUseCorrelationIds, _headerTypeSerializationConfiguration, serviceProvider);
 
                 busProxy = new BusProxy(_configRabbitMqConfig.Id, bus);
 

--- a/src/EasyNetQ.HostedService/Internals/HeaderMessageSerializationStrategy.cs
+++ b/src/EasyNetQ.HostedService/Internals/HeaderMessageSerializationStrategy.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+
+namespace EasyNetQ.HostedService.Internals
+{
+    public class HeaderMessageSerializationStrategy : IMessageSerializationStrategy
+    {
+        private readonly bool _useCorrelationIds;
+        private readonly ISerializer _serializer;
+        private readonly ICorrelationIdGenerationStrategy _correlationIdGenerator;
+        private readonly HeaderTypeSerializationConfiguration _headerTypeSerializationConfiguration;
+        
+        public HeaderMessageSerializationStrategy(
+            bool useCorrelationIds,
+            HeaderTypeSerializationConfiguration headerTypeSerializationConfiguration,
+            ISerializer serializer,
+            ICorrelationIdGenerationStrategy correlationIdGenerator)
+        {
+            _useCorrelationIds = useCorrelationIds;
+            _serializer = serializer;
+            _correlationIdGenerator = correlationIdGenerator;
+            _headerTypeSerializationConfiguration = headerTypeSerializationConfiguration;
+        }
+        
+        public SerializedMessage SerializeMessage(IMessage message)
+        {
+            var bytes = _serializer.MessageToBytes(message.MessageType, message.GetBody());
+            var properties = message.Properties;
+
+            var typeHeader = _headerTypeSerializationConfiguration
+                .TypeMappings
+                .SingleOrDefault(v => message.MessageType == v.Value)
+                .Key;
+
+            if (string.IsNullOrEmpty(typeHeader))
+            {
+                throw new EasyNetQException(
+                    $"Did not find a unique mapping for the specified type {message.MessageType}");
+            }
+            
+            properties.Headers.Add(_headerTypeSerializationConfiguration.TypeHeader, typeHeader);
+            
+            if (_useCorrelationIds && string.IsNullOrEmpty(properties.CorrelationId))
+            {
+                properties.CorrelationId = _correlationIdGenerator.GetCorrelationId();
+            }
+
+            return new SerializedMessage(properties, bytes);
+        }
+
+        public IMessage DeserializeMessage(MessageProperties properties, byte[] body)
+        {
+            var typeHeaderValueExists = properties.Headers.TryGetValue(
+                _headerTypeSerializationConfiguration.TypeHeader,
+                out var typeFromHeader);
+
+            if (!typeHeaderValueExists)
+            {
+                throw new UnhandledHeaderTypeException("Type header not present on message");
+            }
+
+            var typeExistsInMapping = _headerTypeSerializationConfiguration.TypeMappings.TryGetValue(
+                System.Text.Encoding.Default.GetString((byte[])typeFromHeader),
+                out var messageType);
+
+            if (!typeExistsInMapping)
+            {
+                throw new UnhandledHeaderTypeException("Message type from header not found in mapping");
+            }
+            
+            var message = _serializer.BytesToMessage(messageType, body);
+
+            return MessageFactory.CreateInstance(messageType, message, properties);
+        }
+    }
+}

--- a/src/EasyNetQ.HostedService/Internals/HeaderTypeSerializationConfiguration.cs
+++ b/src/EasyNetQ.HostedService/Internals/HeaderTypeSerializationConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EasyNetQ.HostedService.Internals
+{
+    public class HeaderTypeSerializationConfiguration
+    {
+        public string TypeHeader { get; set; }
+        
+        public Dictionary<string, Type> TypeMappings { get; set; }
+    }
+}

--- a/src/EasyNetQ.HostedService/Internals/MessageSerializationStrategy.cs
+++ b/src/EasyNetQ.HostedService/Internals/MessageSerializationStrategy.cs
@@ -1,0 +1,9 @@
+﻿namespace EasyNetQ.HostedService.Internals
+{
+    public enum MessageSerializationStrategy
+    {
+        Typed,
+        UnTyped,
+        Header
+    }
+}

--- a/src/EasyNetQ.HostedService/Internals/UnhandledHeaderTypeException.cs
+++ b/src/EasyNetQ.HostedService/Internals/UnhandledHeaderTypeException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+using EasyNetQ.HostedService.Abstractions;
+
+namespace EasyNetQ.HostedService.Internals
+{
+    public class UnhandledHeaderTypeException : Exception, INackWithRequeueException
+    {
+        /// <inheritdoc />
+        public UnhandledHeaderTypeException() { }
+
+        /// <inheritdoc />
+        public UnhandledHeaderTypeException(string message) : base(message) { }
+
+        /// <inheritdoc />
+        public UnhandledHeaderTypeException(string format, params object[] args) : base(string.Format(format, args)) { }
+
+        /// <inheritdoc />
+        public UnhandledHeaderTypeException(string message, Exception inner) : base(message, inner) { }
+
+        /// <inheritdoc />
+        protected UnhandledHeaderTypeException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        
+    }
+}


### PR DESCRIPTION
This MR adds a new serialization strategy that allows the serialization/deserialization of messages based on the presence and value of a specific header. This is to allow consumers to consume messages that do not have their [message types](https://www.rabbitmq.com/consumers.html#message-properties) set to the name of the assembly of the serialization/deserialization target.

To use this functionality, simply register a producer or consumer as follows:

```
new RabbitMqServiceBuilder<MyConusmer>()
    .WithRabbitMqConfig(rabbitMqConsumerConfiguration)
    .WithHeaderTypedMessages(new HeaderTypeSerializationConfiguration
    {
        TypeHeader = "x-my-header",
        TypeMappings = new Dictionary<string, Type>
        {
            {"my.type", typeof(MyType)}
        }
    })
    .Build(_serviceCollection)
    .Add(_serviceCollection, typeof(MyConusmer));
```